### PR TITLE
Add thumbs up for "drink", "switch", and "remove" commands

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -79,6 +79,7 @@ physics decrement - remove the last drink event
             data.insert_bottle(ma[2], ma[3], author_id)
         elif ma[1] == "remove":
             data.delete_bottle(ma[2], author_id)
+            self.reactToMessage(message_object.uid, MessageReaction.YES)
         elif ma[1] == "switch":
             data.switch_bottle(ma[2], author_id)
             self.reactToMessage(message_object.uid, MessageReaction.YES)

--- a/bot.py
+++ b/bot.py
@@ -7,7 +7,7 @@ import re
 import sys
 
 from fbchat import Client, log
-from fbchat.models import Message, ThreadType
+from fbchat.models import Message, ThreadType, MessageReaction
 
 import data
 
@@ -81,6 +81,7 @@ physics decrement - remove the last drink event
             data.delete_bottle(ma[2], author_id)
         elif ma[1] == "switch":
             data.switch_bottle(ma[2], author_id)
+            self.reactToMessage(message_object.uid, MessageReaction.YES)
         elif ma[1] == "rename":
             pass
         elif ma[1] == "list":
@@ -91,7 +92,7 @@ physics decrement - remove the last drink event
             homie_increment(self, thread_id, thread_type, author_id)
         elif ma[1] == "drink":
             if data.insert_drink(author_id, bottle_name=ma[2]):
-                self.reactToMessage(message_object.uid, '👍')
+                self.reactToMessage(message_object.uid, MessageReaction.YES)
         elif ma[1] == "stats":
             verbose_list = ["-v", "full", "verbose", "--verbose"]
             if len(ma)>2 and ma[2] in verbose_list:

--- a/bot.py
+++ b/bot.py
@@ -90,8 +90,8 @@ physics decrement - remove the last drink event
         elif ma[1] == "increment" or ma[1] == "inc":
             homie_increment(self, thread_id, thread_type, author_id)
         elif ma[1] == "drink":
-            data.insert_drink(author_id, bottle_name=ma[2])
-            self.reactToMessage(message_object.uid, '👍')
+            if data.insert_drink(author_id, bottle_name=ma[2]):
+                self.reactToMessage(message_object.uid, '👍')
         elif ma[1] == "stats":
             verbose_list = ["-v", "full", "verbose", "--verbose"]
             if len(ma)>2 and ma[2] in verbose_list:

--- a/bot.py
+++ b/bot.py
@@ -44,12 +44,12 @@ class HydroBot(Client):
             ma = messageText.split() # message array
 
             if ma[0].lower() == "physics":
-                process_message(self, author_id, ma, thread_id, thread_type)
+                process_message(self, author_id, ma, thread_id, thread_type, message_object)
             elif messageText == client.fetchThreadInfo(thread_id)[thread_id].emoji:
                 homie_increment(self, thread_id, thread_type, author_id)
         super(HydroBot, self).onMessage(author_id=author_id, message_object=message_object, thread_id=thread_id, thread_type=thread_type, **kwargs)
 
-def process_message(self, author_id, ma, thread_id, thread_type):
+def process_message(self, author_id, ma, thread_id, thread_type, message_object):
     if author_id != self.uid:
         print(ma)
         user = self.fetchUserInfo(author_id)[author_id]
@@ -91,6 +91,7 @@ physics decrement - remove the last drink event
             homie_increment(self, thread_id, thread_type, author_id)
         elif ma[1] == "drink":
             data.insert_drink(author_id, bottle_name=ma[2])
+            self.reactToMessage(message_object.uid, '👍')
         elif ma[1] == "stats":
             verbose_list = ["-v", "full", "verbose", "--verbose"]
             if len(ma)>2 and ma[2] in verbose_list:

--- a/data.py
+++ b/data.py
@@ -79,11 +79,15 @@ def insert_drink(homie_fb_id, bottle_name=None):
         bottle_entry = execute_statement("SELECT * FROM bottles WHERE homie_fb_id = %s AND bottle_name = %s;", args=(homie_fb_id, bottle_name), ret=True)
         bottle_id = bottle_entry[0][0]
 
-    # Adds a drink event with the currently selected bottle id
-    add_drink_sql = """INSERT INTO drinks (homie_fb_id, bottle_id) VALUES(%s, %s);"""
-    execute_statement(add_drink_sql, (homie_fb_id, bottle_id))
-    # Updates the total number of drink events logged by that bottle
-    execute_statement("UPDATE bottles set num_drinks = num_drinks+1 WHERE homie_fb_id = %s AND bottle_id = %s;", args=(homie_fb_id, bottle_id))
+    if bottle_id:
+        # Adds a drink event with the currently selected bottle id
+        add_drink_sql = """INSERT INTO drinks (homie_fb_id, bottle_id) VALUES(%s, %s);"""
+        execute_statement(add_drink_sql, (homie_fb_id, bottle_id))
+        # Updates the total number of drink events logged by that bottle
+        execute_statement("UPDATE bottles set num_drinks = num_drinks+1 WHERE homie_fb_id = %s AND bottle_id = %s;", args=(homie_fb_id, bottle_id))
+        return True
+    else:
+        return False
 
 def insert_homie(homie_fb_id, homie_name):
     insert_bottle("NULL", "0", homie_fb_id)


### PR DESCRIPTION
Adds an acknowledgment of the drink command invocation in chat to indicate that the operation was completed successfully.

Also ACKs "switch" and "remove" to cover all commands that use a bottle name.